### PR TITLE
fix: support sites with auth

### DIFF
--- a/src/plugins/blocks/blocks.js
+++ b/src/plugins/blocks/blocks.js
@@ -134,7 +134,7 @@ export async function fetchBlock(path) {
     window.blocks = {};
   }
   if (!window.blocks[path]) {
-    const resp = await fetch(`${path}.plain.html`);
+    const resp = await fetch(`${path}.plain.html`, { credentials: 'include' });
     if (!resp.ok) return;
 
     const html = await resp.text();

--- a/src/utils/library.js
+++ b/src/utils/library.js
@@ -19,7 +19,7 @@ import { APP_EVENTS, PLUGIN_EVENTS } from '../events/events.js';
  * @returns The library JSON
  */
 export async function fetchLibrary(href) {
-  const resp = await fetch(href);
+  const resp = await fetch(href, { credentials: 'include' });
   if (!resp.ok) throw new Error('unable to load library JSON');
   return resp.json();
 }


### PR DESCRIPTION
Set the `credentials: 'include'` param on fetch requests to support sites with authentication