### PR TITLE
feat: add rum collection

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -42,6 +42,7 @@ export default merge(baseConfig, {
     copy({
       targets: [{ src: 'src/plugins/**/*', dest: './dist' },
         { src: 'src/utils/dom.js', dest: './dist' },
+        { src: 'src/utils/rum.js', dest: './dist' },
         { src: 'src/locales', dest: './dist' },
         { src: 'src/events/events.js', dest: './dist' }],
       // set flatten to false to preserve folder structure

--- a/src/app.js
+++ b/src/app.js
@@ -173,7 +173,7 @@ class SidekickLibrary extends LitElement {
     await loadLibrary();
 
     // Track library opened
-    sampleRUM('library:opened', { source: window.location.href });
+    sampleRUM('library:opened');
   }
 
   renderIllustratedMessage() {

--- a/src/app.js
+++ b/src/app.js
@@ -173,7 +173,7 @@ class SidekickLibrary extends LitElement {
     await loadLibrary();
 
     // Track library opened
-    sampleRUM('library:opened');
+    sampleRUM('library:opened', { source: window.location.href });
   }
 
   renderIllustratedMessage() {

--- a/src/app.js
+++ b/src/app.js
@@ -173,7 +173,7 @@ class SidekickLibrary extends LitElement {
     await loadLibrary();
 
     // Track library opened
-    sampleRUM('libraryopened');
+    sampleRUM('library:opened');
   }
 
   renderIllustratedMessage() {

--- a/src/app.js
+++ b/src/app.js
@@ -16,6 +16,7 @@ import { EventBus } from './events/eventbus.js';
 import { createTag } from './utils/dom.js';
 import { APP_EVENTS } from './events/events.js';
 import { loadLibrary } from './utils/library.js';
+import { sampleRUM } from './utils/rum.js';
 
 class SidekickLibrary extends LitElement {
   static properties = {
@@ -170,6 +171,9 @@ class SidekickLibrary extends LitElement {
     AppModel.appStore.context = this.config;
 
     await loadLibrary();
+
+    // Track library opened
+    sampleRUM('libraryopened');
   }
 
   renderIllustratedMessage() {

--- a/src/plugins/blocks/blocks.js
+++ b/src/plugins/blocks/blocks.js
@@ -121,7 +121,7 @@ function copyBlockToClipboard(wrapper, name, blockURL) {
   copyBlock(blockTable, sectionMetadataTable);
 
   // Track block copy event
-  sampleRUM('library:blockcopied', { source: window.location.href, target: blockURL });
+  sampleRUM('library:blockcopied', { target: blockURL });
 }
 
 /**
@@ -222,7 +222,7 @@ export async function decorate(container, data) {
     });
 
     // Track block view
-    sampleRUM('library:blockviewed', { source: window.location.href, target: blockData.url });
+    sampleRUM('library:blockviewed', { target: blockData.url });
   });
 
   blockList.addEventListener('CopyBlock', (e) => {

--- a/src/plugins/blocks/blocks.js
+++ b/src/plugins/blocks/blocks.js
@@ -26,6 +26,7 @@ import {
 import {
   createTag,
 } from '../../utils/dom.js';
+import { sampleRUM } from '../../utils/rum.js';
 
 /**
  * Renders the scaffolding for the block plugin
@@ -194,6 +195,9 @@ export async function decorate(container, data) {
 
       copyBlock(blockTable, sectionMetadataTable);
       container.dispatchEvent(new CustomEvent('Toast', { detail: { message: 'Copied Block' } }));
+
+      // Track block copy event
+      sampleRUM('blockcopied');
     });
 
     const frameView = content.querySelector('.frame-view');
@@ -211,6 +215,9 @@ export async function decorate(container, data) {
     desktopViewButton?.addEventListener('click', () => {
       frameView.style.width = '100%';
     });
+
+    // Track block view
+    sampleRUM('blockviewed');
   });
 
   blockList.addEventListener('CopyBlock', (e) => {
@@ -238,6 +245,9 @@ export async function decorate(container, data) {
 
     // Show toast
     container.dispatchEvent(new CustomEvent('Toast', { detail: { message: 'Copied Block' } }));
+
+    // Track block copy event
+    sampleRUM('blockcopied');
   });
 
   const search = content.querySelector('sp-search');

--- a/src/plugins/blocks/blocks.js
+++ b/src/plugins/blocks/blocks.js
@@ -197,7 +197,7 @@ export async function decorate(container, data) {
       container.dispatchEvent(new CustomEvent('Toast', { detail: { message: 'Copied Block' } }));
 
       // Track block copy event
-      sampleRUM('blockcopied');
+      sampleRUM('library:blockcopied');
     });
 
     const frameView = content.querySelector('.frame-view');

--- a/src/plugins/blocks/blocks.js
+++ b/src/plugins/blocks/blocks.js
@@ -217,7 +217,7 @@ export async function decorate(container, data) {
     });
 
     // Track block view
-    sampleRUM('blockviewed');
+    sampleRUM('library:blockviewed');
   });
 
   blockList.addEventListener('CopyBlock', (e) => {

--- a/src/utils/rum.js
+++ b/src/utils/rum.js
@@ -10,21 +10,19 @@
  * governing permissions and limitations under the License.
  */
 
-const LIBRARY_LOCATION = 'https://www.hlx.live/tools/sidekick/library/index.js';
-
 export function sampleRUM(checkpoint, data = {}) {
   sampleRUM.defer = sampleRUM.defer || [];
   const defer = (fnname) => {
     sampleRUM[fnname] = sampleRUM[fnname]
-        || ((...args) => sampleRUM.defer.push({ fnname, args }));
+      || ((...args) => sampleRUM.defer.push({ fnname, args }));
   };
   sampleRUM.drain = sampleRUM.drain
-      || ((dfnname, fn) => {
-        sampleRUM[dfnname] = fn;
-        sampleRUM.defer
-          .filter(({ fnname }) => dfnname === fnname)
-          .forEach(({ fnname, args }) => sampleRUM[fnname](...args));
-      });
+    || ((dfnname, fn) => {
+      sampleRUM[dfnname] = fn;
+      sampleRUM.defer
+        .filter(({ fnname }) => dfnname === fnname)
+        .forEach(({ fnname, args }) => sampleRUM[fnname](...args));
+    });
   sampleRUM.on = (chkpnt, fn) => { sampleRUM.cases[chkpnt] = fn; };
   defer('observe');
   defer('cwv');
@@ -35,7 +33,7 @@ export function sampleRUM(checkpoint, data = {}) {
       const weight = (usp.get('rum') === 'on') ? 1 : 100; // with parameter, weight is 1. Defaults to 100.
       // eslint-disable-next-line no-bitwise
       const hashCode = s => s.split('').reduce((a, b) => (((a << 5) - a) + b.charCodeAt(0)) | 0, 0);
-      const id = `${hashCode(LIBRARY_LOCATION)}-${new Date().getTime()}-${Math.random().toString(16).substr(2, 14)}`;
+      const id = `${hashCode(window.location.href)}-${new Date().getTime()}-${Math.random().toString(16).substr(2, 14)}`;
       const random = Math.random();
       const isSelected = (random * weight < 1);
       // eslint-disable-next-line object-curly-newline
@@ -45,22 +43,12 @@ export function sampleRUM(checkpoint, data = {}) {
     if (window.hlx && window.hlx.rum && window.hlx.rum.isSelected) {
       const sendPing = (pdata = data) => {
         // eslint-disable-next-line object-curly-newline, max-len, no-use-before-define
-        const body = JSON.stringify({ weight, id, referer: LIBRARY_LOCATION, generation: window.hlx.RUM_GENERATION, checkpoint, ...data });
+        const body = JSON.stringify({ weight, id, referer: window.location.href, checkpoint, ...data });
         const url = `https://rum.hlx.page/.rum/${weight}`;
         // eslint-disable-next-line no-unused-expressions
         navigator.sendBeacon(url, body);
         // eslint-disable-next-line no-console
         console.debug(`ping:${checkpoint}`, pdata);
-      };
-      sampleRUM.cases = sampleRUM.cases || {
-        cwv: () => sampleRUM.cwv(data) || true,
-        lazy: () => {
-          // use classic script to avoid CORS issues
-          const script = document.createElement('script');
-          script.src = 'https://rum.hlx.page/.rum/@adobe/helix-rum-enhancer@^1/src/index.js';
-          document.head.appendChild(script);
-          return true;
-        },
       };
       sendPing(data);
       if (sampleRUM.cases[checkpoint]) { sampleRUM.cases[checkpoint](); }

--- a/src/utils/rum.js
+++ b/src/utils/rum.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const LIBRARY_LOCATION = 'https://www.hlx.live/tools/sidekick/library/index.js';
+
+export function sampleRUM(checkpoint, data = {}) {
+  sampleRUM.defer = sampleRUM.defer || [];
+  const defer = (fnname) => {
+    sampleRUM[fnname] = sampleRUM[fnname]
+        || ((...args) => sampleRUM.defer.push({ fnname, args }));
+  };
+  sampleRUM.drain = sampleRUM.drain
+      || ((dfnname, fn) => {
+        sampleRUM[dfnname] = fn;
+        sampleRUM.defer
+          .filter(({ fnname }) => dfnname === fnname)
+          .forEach(({ fnname, args }) => sampleRUM[fnname](...args));
+      });
+  sampleRUM.on = (chkpnt, fn) => { sampleRUM.cases[chkpnt] = fn; };
+  defer('observe');
+  defer('cwv');
+  try {
+    window.hlx = window.hlx || {};
+    if (!window.hlx.rum) {
+      const usp = new URLSearchParams(window.location.search);
+      const weight = (usp.get('rum') === 'on') ? 1 : 100; // with parameter, weight is 1. Defaults to 100.
+      // eslint-disable-next-line no-bitwise
+      const hashCode = s => s.split('').reduce((a, b) => (((a << 5) - a) + b.charCodeAt(0)) | 0, 0);
+      const id = `${hashCode(LIBRARY_LOCATION)}-${new Date().getTime()}-${Math.random().toString(16).substr(2, 14)}`;
+      const random = Math.random();
+      const isSelected = (random * weight < 1);
+      // eslint-disable-next-line object-curly-newline
+      window.hlx.rum = { weight, id, random, isSelected, sampleRUM };
+    }
+    const { weight, id } = window.hlx.rum;
+    if (window.hlx && window.hlx.rum && window.hlx.rum.isSelected) {
+      const sendPing = (pdata = data) => {
+        // eslint-disable-next-line object-curly-newline, max-len, no-use-before-define
+        const body = JSON.stringify({ weight, id, referer: LIBRARY_LOCATION, generation: window.hlx.RUM_GENERATION, checkpoint, ...data });
+        const url = `https://rum.hlx.page/.rum/${weight}`;
+        // eslint-disable-next-line no-unused-expressions
+        navigator.sendBeacon(url, body);
+        // eslint-disable-next-line no-console
+        console.debug(`ping:${checkpoint}`, pdata);
+      };
+      sampleRUM.cases = sampleRUM.cases || {
+        cwv: () => sampleRUM.cwv(data) || true,
+        lazy: () => {
+          // use classic script to avoid CORS issues
+          const script = document.createElement('script');
+          script.src = 'https://rum.hlx.page/.rum/@adobe/helix-rum-enhancer@^1/src/index.js';
+          document.head.appendChild(script);
+          return true;
+        },
+      };
+      sendPing(data);
+      if (sampleRUM.cases[checkpoint]) { sampleRUM.cases[checkpoint](); }
+    }
+  } catch (error) {
+    // something went wrong
+  }
+}


### PR DESCRIPTION
@trieloff Not sure how much you are aware of this project but I am working on a feature similar to the milo block library. David asked me to collect some RUM data for this. 

First time trying to do any sort of RUM collection so 100% possible I'm doing it wrong ;)

Couple things to note on how this works..
1. Customers will run the application same origin as the content. The page containing the application is a static HTML file that lives in the customers codebus. The source for the application though comes from `https://www.hlx.live/tools/sidekick/library/index.js`. 
2. When a block is loaded in the block library the `plain.html` file is fetched for the block, stripped of any other blocks in the page and editable content is decorated with `contenteditble`.
3. I then request the same page (without .plain.html) and replace the `main` element with the decorate block.

In terms of rum, I've modified `sampleRUM` to always use `https://www.hlx.live/tools/sidekick/library/index.js` as the `referer` and then track the following checkpoints.

Collection checkpoints

`libraryopened` -> When the application is opened
`blockviewed` -> When the user loads a block 
`blockcopied` -> When the user copies a block

wdyt?