### PR TITLE
fix: duplicate section metadata when pasted from block with only section metadata

### DIFF
--- a/src/plugins/blocks/blocks.js
+++ b/src/plugins/blocks/blocks.js
@@ -99,12 +99,18 @@ function renderFrameSplitContainer() {
 }
 
 function copyBlockToClipboard(wrapper, name, blockURL) {
-  const element = wrapper.querySelector('div[class]');
-  const blockTable = getTable(
-    element,
-    name,
-    blockURL,
-  );
+  // Get the first block element ignoring any section metadata blocks
+  const element = wrapper.querySelector(':scope > div:not(.section-metadata)');
+  let blockTable = '';
+
+  // If the wrapper has no block, leave block table empty
+  if (element) {
+    blockTable = getTable(
+      element,
+      name,
+      blockURL,
+    );
+  }
 
   // Does the block have section metadata?
   let sectionMetadataTable;
@@ -113,7 +119,7 @@ function copyBlockToClipboard(wrapper, name, blockURL) {
   // Create a table for the section metadata
     sectionMetadataTable = getTable(
       sectionMetadata,
-      'section-metadata',
+      'Section metadata',
       blockURL,
     );
   }


### PR DESCRIPTION
Fix #34 