### PR TITLE
fix: only call decorateIcons in devMode

### DIFF
--- a/src/components/block-renderer/block-renderer.js
+++ b/src/components/block-renderer/block-renderer.js
@@ -316,6 +316,7 @@ export class BlockRenderer extends LitElement {
       const { body: iframeBody } = iframeWindow.document;
 
       // When in dev mode, decorate icons with page origin
+      /* c8 ignore next 3 */
       if (isDev()) {
         this.decorateIcons(iframeBody, origin);
       }

--- a/src/components/block-renderer/block-renderer.js
+++ b/src/components/block-renderer/block-renderer.js
@@ -51,6 +51,7 @@ export class BlockRenderer extends LitElement {
    * Replace icons with inline SVG using the origin of the block
    * @param {Element} element
    */
+  /* c8 ignore next 19 */
   decorateIcons(element, origin) {
     element.querySelectorAll('span.icon').forEach(async (span) => {
       if (span.classList.length < 2 || !span.classList[1].startsWith('icon-')) {

--- a/src/components/block-renderer/block-renderer.js
+++ b/src/components/block-renderer/block-renderer.js
@@ -51,7 +51,6 @@ export class BlockRenderer extends LitElement {
    * Replace icons with inline SVG using the origin of the block
    * @param {Element} element
    */
-  /* c8 ignore next 19 */
   decorateIcons(element, origin) {
     element.querySelectorAll('span.icon').forEach(async (span) => {
       if (span.classList.length < 2 || !span.classList[1].startsWith('icon-')) {
@@ -317,7 +316,6 @@ export class BlockRenderer extends LitElement {
       const { body: iframeBody } = iframeWindow.document;
 
       // When in dev mode, decorate icons with page origin
-      /* c8 ignore next 3 */
       if (isDev()) {
         this.decorateIcons(iframeBody, origin);
       }

--- a/src/components/block-renderer/block-renderer.js
+++ b/src/components/block-renderer/block-renderer.js
@@ -315,8 +315,10 @@ export class BlockRenderer extends LitElement {
       const { contentWindow: iframeWindow } = frame;
       const { body: iframeBody } = iframeWindow.document;
 
-      // Decorate icons with page origin
-      this.decorateIcons(iframeBody, origin);
+      // When in dev mode, decorate icons with page origin
+      if (isDev()) {
+        this.decorateIcons(iframeBody, origin);
+      }
 
       // On scroll remove the popover
       frame.contentDocument.addEventListener('scroll', () => {

--- a/test/components/block-renderer/block-renderer.test.js
+++ b/test/components/block-renderer/block-renderer.test.js
@@ -214,6 +214,89 @@ describe('BlockRenderer', () => {
     });
   });
 
+  describe('decorateIcons', () => {
+    let fetchStub;
+
+    beforeEach(() => {
+      fetchStub = stub(window, 'fetch');
+    });
+
+    afterEach(() => {
+      fetchStub.restore();
+    });
+
+    it('should decorate icons as svg correctly', async () => {
+      // Mock successful fetch response
+      const mockResponse = new Response('<svg>Mocked Icon</svg>', { status: 200 });
+      fetchStub.resolves(mockResponse);
+
+      // Create a sample element and call the function
+      const element = document.createElement('div');
+      element.innerHTML = `
+        <span class="icon icon-example1"></span>
+      `;
+
+      const origin = 'http://example.com';
+
+      // Call the function
+      blockRenderer.decorateIcons(element, origin);
+
+      await waitUntil(
+        () => recursiveQuery(element, '.icon-example1 svg'),
+        'Element did not render children',
+      );
+
+      // Write your assertions here
+      expect(element.querySelector('.icon-example1 svg')).to.exist;
+    });
+
+    it('should decorate icons as svg correctly', async () => {
+      // Mock successful fetch response
+      const mockResponse = new Response('<svg><style></style>Mocked Icon</svg>', { status: 200 });
+      fetchStub.resolves(mockResponse);
+
+      // Create a sample element and call the function
+      const element = document.createElement('div');
+      element.innerHTML = `
+        <span class="icon icon-example1"></span>
+      `;
+
+      const origin = 'http://example.com';
+
+      // Call the function
+      blockRenderer.decorateIcons(element, origin);
+
+      await waitUntil(
+        () => recursiveQuery(element, '.icon-example1 img'),
+        'Element did not render children',
+      );
+
+      // Write your assertions here
+      expect(element.querySelector('.icon-example1 img')).to.exist;
+    });
+
+    it('no icon to decorate', async () => {
+      // Create a sample element and call the function
+      const element = document.createElement('div');
+      element.innerHTML = `
+        <span class="icon"></span>
+      `;
+
+      const origin = 'http://example.com';
+
+      // Call the function
+      blockRenderer.decorateIcons(element, origin);
+
+      await waitUntil(
+        () => recursiveQuery(element, '.icon'),
+        'Element did not render children',
+      );
+
+      // Write your assertions here
+      expect(element.querySelector('.icon-example1 img')).to.not.exist;
+    });
+  });
+
   describe('default content', () => {
     it('default content should render', async () => {
       await renderDefaultContent(blockRenderer);


### PR DESCRIPTION
When the sidekick library is running typically it is running on the same origin as the content and icons.

When in dev mode though (aka doing sidekick library development), the origin is different than the content so I was calling decorateIcons myself on the decorated content in order to change the loading location of the svg to be the same origin as the content (and not the window location). This has been fine up until now but a customer has an issue so I'm putting a check in front to only call decorateIcons when in dev mode.

Fix #61