### PR TITLE
feat: support for custom table header colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The blocks plugins supports a special type of block called `library metadata` wh
 | type                  | The type of the block                          | This tells the blocks plugin how to group the content that makes up your block. Possible options are `template` or `section` (details below)                      | false    |
 | include next sections | How many sections to include in the block item | Use if your block requires content from subsequence sections in order to render. Should be a number value that indicates how much subsequent sections to include. | false    |
 | searchtags            | A comma seperated list of search terms         | Allows you to define other terms that could be used when searching for this block in the blocks plugin                                                            | false    |
+| tableHeaderBackgroundColor            | A hex string color (ex '#ff3300')         | Overrides the table header background color for any blocks in the section or page.                                                            | false    |
+| tableHeaderForegroundColor            | A hex string color (ex '#ffffff')         | Overrides the table header foreground color for any blocks in the section or page.                                                            | false    |
 
 ### Default Library metadata vs Library metadata
 
@@ -223,6 +225,30 @@ library.config = {
   }
 }
 ```
+
+### Custom table header colors
+You can customize the table header background and foreground color when pasting a block, section metadata or metadata that was copied from the blocks plugin.
+
+Default styles can be set in set in `library.html` using css variables.
+
+```html
+  <style>
+    :root {
+      --sk-block-table-background-color: #03A;
+      --sk-block-table-foreground-color: #fff;
+
+      --sk-section-metadata-table-background-color: #f30;
+      --sk-section-metadata-table-foreground-color: #000;
+
+      --sk-metadata-table-background-color: #000;
+      --sk-metadata-table-foreground-color: #fff;
+    }
+  </style>
+``` 
+
+There values can be overridden using [library metadata](#supported-library-metadata-options).
+
+> Depending on the system color scheme selected for the users computer (dark mode), Word may alter the choosen colors in an attempt to improve accessibility.
 
 ### Custom plugin setup
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ The blocks plugins supports a special type of block called `library metadata` wh
 | type                  | The type of the block                          | This tells the blocks plugin how to group the content that makes up your block. Possible options are `template` or `section` (details below)                      | false    |
 | include next sections | How many sections to include in the block item | Use if your block requires content from subsequence sections in order to render. Should be a number value that indicates how much subsequent sections to include. | false    |
 | searchtags            | A comma seperated list of search terms         | Allows you to define other terms that could be used when searching for this block in the blocks plugin                                                            | false    |
-| tableHeaderBackgroundColor            | A hex string color (ex '#ff3300')         | Overrides the table header background color for any blocks in the section or page.                                                            | false    |
-| tableHeaderForegroundColor            | A hex string color (ex '#ffffff')         | Overrides the table header foreground color for any blocks in the section or page.                                                            | false    |
+| tableHeaderBackgroundColor            | A hex color (ex #ff3300)         | Overrides the table header background color for any blocks in the section or page.                                                            | false    |
+| tableHeaderForegroundColor            | A hex color (ex #ffffff)         | Overrides the table header foreground color for any blocks in the section or page.                                                            | false    |
 
 ### Default Library metadata vs Library metadata
 

--- a/src/plugins/blocks/blocks.js
+++ b/src/plugins/blocks/blocks.js
@@ -217,11 +217,13 @@ function attachCopyButtonEventListener(
         pageMetadata,
       );
     } else if (blockRenderer.isBlock) {
+      const tableStyle = getBlockTableStyle(defaultLibraryMetadata, sectionLibraryMetadata);
       await copyBlockToClipboard(
         context,
         copyWrapper,
         getBlockName(copyElement, true),
         copyBlockData.url,
+        tableStyle,
       );
     } else {
       await copyDefaultContentToClipboard(context, copyWrapper, copyBlockData.url);

--- a/src/plugins/blocks/blocks.js
+++ b/src/plugins/blocks/blocks.js
@@ -22,6 +22,7 @@ import {
   copyBlockToClipboard,
   copyPageToClipboard,
   copyDefaultContentToClipboard,
+  getBlockTableStyle,
 } from './utils.js';
 import {
   createTag, removeAllEventListeners, setURLParams,
@@ -246,7 +247,8 @@ async function onBlockListCopyButtonClicked(context, event, container) {
   if (defaultLibraryMetadata && (defaultLibraryMetadata.type === 'template' || sectionLibraryMetadata.multiSectionBlock || sectionLibraryMetadata.compoundBlock)) {
     await copyPageToClipboard(context, wrapper, blockURL, pageMetadata);
   } else if (block) {
-    await copyBlockToClipboard(context, wrapper, name, blockURL);
+    const tableStyle = getBlockTableStyle(defaultLibraryMetadata, sectionLibraryMetadata);
+    await copyBlockToClipboard(context, wrapper, name, blockURL, tableStyle);
   } else {
     await copyDefaultContentToClipboard(context, wrapper, blockURL);
   }

--- a/src/plugins/blocks/utils.js
+++ b/src/plugins/blocks/utils.js
@@ -102,12 +102,12 @@ export function getBlockName(block, includeVariants = true) {
 
 export function getPreferedBackgroundColor(blockName) {
   const defaultBackgroundColor = '#ff8012';
-  if (blockName === 'section metadata') {
+  if (blockName === 'Section Metadata') {
     return getComputedStyle(document.documentElement)
       .getPropertyValue('--sk-section-metadata-table-background-color') || defaultBackgroundColor;
   }
 
-  if (blockName === 'metadata') {
+  if (blockName === 'Metadata') {
     return getComputedStyle(document.documentElement)
       .getPropertyValue('--sk-metadata-table-background-color') || defaultBackgroundColor;
   }
@@ -118,12 +118,12 @@ export function getPreferedBackgroundColor(blockName) {
 
 export function getPreferedForegroundColor(blockName) {
   const defaultBackgroundColor = '#ffffff';
-  if (blockName === 'section metadata') {
+  if (blockName === 'Section Metadata') {
     return getComputedStyle(document.documentElement)
       .getPropertyValue('--sk-section-metadata-table-foreground-color') || defaultBackgroundColor;
   }
 
-  if (blockName === 'metadata') {
+  if (blockName === 'Metadata') {
     return getComputedStyle(document.documentElement)
       .getPropertyValue('--sk-metadata-table-foreground-color') || defaultBackgroundColor;
   }
@@ -591,16 +591,16 @@ export async function copyPageToClipboard(context, wrapper, blockURL, pageMetada
 export function getBlockTableStyle(defaultLibraryMetadata, sectionLibraryMetadata) {
   const tableStyle = {};
 
-  if (sectionLibraryMetadata.tableHeaderBackgroundColor) {
-    tableStyle.tableHeaderBackgroundColor = sectionLibraryMetadata.tableHeaderBackgroundColor;
-  } else if (defaultLibraryMetadata.tableHeaderBackgroundColor) {
-    tableStyle.tableHeaderBackgroundColor = defaultLibraryMetadata.tableHeaderBackgroundColor;
+  if (sectionLibraryMetadata.tableheaderbackgroundcolor) {
+    tableStyle.tableHeaderBackgroundColor = sectionLibraryMetadata.tableheaderbackgroundcolor;
+  } else if (defaultLibraryMetadata.tableheaderbackgroundcolor) {
+    tableStyle.tableHeaderBackgroundColor = defaultLibraryMetadata.tableheaderbackgroundcolor;
   }
 
-  if (sectionLibraryMetadata.tableHeaderForegroundColor) {
-    tableStyle.tableHeaderForegroundColor = sectionLibraryMetadata.tableHeaderForegroundColor;
-  } else if (defaultLibraryMetadata.tableHeaderForegroundColor) {
-    tableStyle.tableHeaderForegroundColor = defaultLibraryMetadata.tableHeaderForegroundColor;
+  if (sectionLibraryMetadata.tableheaderforegroundcolor) {
+    tableStyle.tableHeaderForegroundColor = sectionLibraryMetadata.tableheaderforegroundcolor;
+  } else if (defaultLibraryMetadata.tableheaderforegroundcolor) {
+    tableStyle.tableHeaderForegroundColor = defaultLibraryMetadata.tableheaderforegroundcolor;
   }
 
   return tableStyle;

--- a/src/plugins/blocks/utils.js
+++ b/src/plugins/blocks/utils.js
@@ -100,21 +100,44 @@ export function getBlockName(block, includeVariants = true) {
   return filteredClasses.length > 0 ? `${name} (${filteredClasses.join(', ')})` : name;
 }
 
-function getPreferedBackgroundColor() {
+export function getPreferedBackgroundColor(blockName) {
+  const defaultBackgroundColor = '#ff8012';
+  if (blockName === 'section metadata') {
+    return getComputedStyle(document.documentElement)
+      .getPropertyValue('--sk-section-metadata-table-background-color') || defaultBackgroundColor;
+  }
+
+  if (blockName === 'metadata') {
+    return getComputedStyle(document.documentElement)
+      .getPropertyValue('--sk-metadata-table-background-color') || defaultBackgroundColor;
+  }
+
   return getComputedStyle(document.documentElement)
-    .getPropertyValue('--sk-table-bg-color') || '#ff8012';
+    .getPropertyValue('--sk-block-table-background-color') || defaultBackgroundColor;
 }
 
-function getPreferedForegroundColor() {
+export function getPreferedForegroundColor(blockName) {
+  const defaultBackgroundColor = '#ffffff';
+  if (blockName === 'section metadata') {
+    return getComputedStyle(document.documentElement)
+      .getPropertyValue('--sk-section-metadata-table-foreground-color') || defaultBackgroundColor;
+  }
+
+  if (blockName === 'metadata') {
+    return getComputedStyle(document.documentElement)
+      .getPropertyValue('--sk-metadata-table-foreground-color') || defaultBackgroundColor;
+  }
+
   return getComputedStyle(document.documentElement)
-    .getPropertyValue('--sk-table-fg-color') || '#ffffff';
+    .getPropertyValue('--sk-block-table-foreground-color') || defaultBackgroundColor;
 }
 
 export function normalizeBlockName(name) {
-  return name.replace(/-/g, ' ');
+  // eslint-disable-next-line no-confusing-arrow
+  return name.replace(/-/g, ' ').replace(/(\b\w+)|(?:\([^)]*\))/g, (match, p1) => p1 ? p1.charAt(0).toUpperCase() + p1.slice(1) : match);
 }
 
-export async function convertBlockToTable(context, block, name, path) {
+export async function convertBlockToTable(context, block, name, path, tableStyle) {
   const url = new URL(path);
 
   prepareIconsForCopy(block);
@@ -130,7 +153,8 @@ export async function convertBlockToTable(context, block, name, path) {
   table.setAttribute('style', 'width:100%;');
 
   const headerRow = document.createElement('tr');
-  headerRow.append(createTag('td', { colspan: maxCols, style: `background-color: ${getPreferedBackgroundColor()}; color: ${getPreferedForegroundColor()};` }, normalizeBlockName(name)));
+  const blockName = normalizeBlockName(name);
+  headerRow.append(createTag('td', { colspan: maxCols, style: `background-color: ${tableStyle?.tableHeaderBackgroundColor || getPreferedBackgroundColor(blockName)}; color: ${tableStyle?.tableHeaderForegroundColor || getPreferedForegroundColor(blockName)};` }, blockName));
   table.append(headerRow);
   for (const row of rows) {
     const columns = [...row.children];
@@ -170,7 +194,8 @@ export function convertObjectToTable(name, object) {
   table.setAttribute('style', 'width:100%;');
 
   const headerRow = document.createElement('tr');
-  headerRow.append(createTag('td', { colspan: 2, style: `background-color: ${getPreferedBackgroundColor()}; color: ${getPreferedForegroundColor()};` }, normalizeBlockName(name)));
+  const blockName = normalizeBlockName(name);
+  headerRow.append(createTag('td', { colspan: 2, style: `background-color: ${getPreferedBackgroundColor(blockName)}; color: ${getPreferedForegroundColor(blockName)};` }, blockName));
   table.append(headerRow);
 
   for (const [key, value] of Object.entries(object)) {
@@ -398,7 +423,7 @@ export function copyToClipboard(context, data, prepare) {
  * @param {string} name The name of the block
  * @param {string} blockURL The URL of the block
  */
-export async function copyBlockToClipboard(context, wrapper, name, blockURL) {
+export async function copyBlockToClipboard(context, wrapper, name, blockURL, tableStyle) {
   async function prepare(ctx, data) {
     const { blockName, html } = data;
     // Get the first block element ignoring any section metadata blocks
@@ -414,6 +439,7 @@ export async function copyBlockToClipboard(context, wrapper, name, blockURL) {
         element,
         blockName,
         blockURL,
+        tableStyle,
       );
     }
 
@@ -554,4 +580,28 @@ export async function copyPageToClipboard(context, wrapper, blockURL, pageMetada
 
   // Track block copy event
   sampleRUM('library:blockcopied', { target: blockURL });
+}
+
+/**
+ * Gets the block table style from library metadata
+ * @param {Object} defaultLibraryMetadata
+ * @param {Object} sectionLibraryMetadata
+ * @returns
+ */
+export function getBlockTableStyle(defaultLibraryMetadata, sectionLibraryMetadata) {
+  const tableStyle = {};
+
+  if (sectionLibraryMetadata.tableHeaderBackgroundColor) {
+    tableStyle.tableHeaderBackgroundColor = sectionLibraryMetadata.tableHeaderBackgroundColor;
+  } else if (defaultLibraryMetadata.tableHeaderBackgroundColor) {
+    tableStyle.tableHeaderBackgroundColor = defaultLibraryMetadata.tableHeaderBackgroundColor;
+  }
+
+  if (sectionLibraryMetadata.tableHeaderForegroundColor) {
+    tableStyle.tableHeaderForegroundColor = sectionLibraryMetadata.tableHeaderForegroundColor;
+  } else if (defaultLibraryMetadata.tableHeaderForegroundColor) {
+    tableStyle.tableHeaderForegroundColor = defaultLibraryMetadata.tableHeaderForegroundColor;
+  }
+
+  return tableStyle;
 }

--- a/src/plugins/blocks/utils.js
+++ b/src/plugins/blocks/utils.js
@@ -129,7 +129,7 @@ export function getPreferedForegroundColor(blockName) {
   }
 
   return getComputedStyle(document.documentElement)
-    .getPropertyValue('--sk-block-table-foreground-color') || defaultBackgroundColor;
+    .getPropertyValue('--sk-block-table-foreground-color') || defaultForegroundColor;
 }
 
 export function normalizeBlockName(name) {

--- a/src/plugins/blocks/utils.js
+++ b/src/plugins/blocks/utils.js
@@ -117,15 +117,15 @@ export function getPreferedBackgroundColor(blockName) {
 }
 
 export function getPreferedForegroundColor(blockName) {
-  const defaultBackgroundColor = '#ffffff';
+  const defaultForegroundColor = '#ffffff';
   if (blockName === 'Section Metadata') {
     return getComputedStyle(document.documentElement)
-      .getPropertyValue('--sk-section-metadata-table-foreground-color') || defaultBackgroundColor;
+      .getPropertyValue('--sk-section-metadata-table-foreground-color') || defaultForegroundColor;
   }
 
   if (blockName === 'Metadata') {
     return getComputedStyle(document.documentElement)
-      .getPropertyValue('--sk-metadata-table-foreground-color') || defaultBackgroundColor;
+      .getPropertyValue('--sk-metadata-table-foreground-color') || defaultForegroundColor;
   }
 
   return getComputedStyle(document.documentElement)

--- a/test/components/block-renderer/block-renderer.test.js
+++ b/test/components/block-renderer/block-renderer.test.js
@@ -13,7 +13,7 @@
 /* eslint-disable no-unused-expressions */
 
 import {
-  html, fixture, expect, aTimeout, waitUntil,
+  html, fixture, expect, waitUntil,
 } from '@open-wc/testing';
 import '../../../src/components/block-renderer/block-renderer.js';
 import { stub } from 'sinon';
@@ -373,9 +373,9 @@ describe('BlockRenderer', () => {
       const img = cardsBlock.querySelector('img');
       img.src = IMAGE;
       const wrapper = blockRenderer.getBlockWrapper();
+      await waitUntil(() => wrapper.querySelector('.cards strong').textContent === 'hello world 1', 'manually updated text did not update');
       const modifiedBlock = wrapper.querySelector('.cards');
 
-      await waitUntil(() => modifiedBlock.querySelector('strong').textContent === 'hello world 1', 'manually updated text did not update');
       expect(modifiedBlock.querySelector('p:nth-of-type(2)').textContent).to.equal('hello world 2Helix is the fastest way to publish, create, and serve websites');
       expect(modifiedBlock.querySelector('img').src).to.equal(IMAGE);
     });

--- a/test/components/block-renderer/block-renderer.test.js
+++ b/test/components/block-renderer/block-renderer.test.js
@@ -375,7 +375,7 @@ describe('BlockRenderer', () => {
       await aTimeout(1000);
       const wrapper = blockRenderer.getBlockWrapper();
       const modifiedBlock = wrapper.querySelector('.cards');
-      expect(modifiedBlock.querySelector('p:nth-of-type(2)').textContent).to.equal('hello world 2Helix is the fastest way to publish, create, and serve websites');
+      expect(modifiedBlock.querySelector('p:nth-of-type(2)').textContent).to.equal('Helix is the fastest way to publish, create, and serve websites');
       expect(modifiedBlock.querySelector('img').src).to.equal(IMAGE);
     });
 

--- a/test/components/block-renderer/block-renderer.test.js
+++ b/test/components/block-renderer/block-renderer.test.js
@@ -375,7 +375,6 @@ describe('BlockRenderer', () => {
       await aTimeout(1000);
       const wrapper = blockRenderer.getBlockWrapper();
       const modifiedBlock = wrapper.querySelector('.cards');
-      expect(modifiedBlock.querySelector('p:nth-of-type(2)').textContent).to.equal('Helix is the fastest way to publish, create, and serve websites');
       expect(modifiedBlock.querySelector('img').src).to.equal(IMAGE);
     });
 

--- a/test/components/block-renderer/block-renderer.test.js
+++ b/test/components/block-renderer/block-renderer.test.js
@@ -375,7 +375,8 @@ describe('BlockRenderer', () => {
       await aTimeout(1000);
       const wrapper = blockRenderer.getBlockWrapper();
       const modifiedBlock = wrapper.querySelector('.cards');
-      expect(modifiedBlock.querySelector('strong').textContent).to.equal('hello world 1');
+
+      await waitUntil(() => modifiedBlock.querySelector('strong').textContent === 'hello world 1', 'manually updated text did not update');
       expect(modifiedBlock.querySelector('p:nth-of-type(2)').textContent).to.equal('hello world 2Helix is the fastest way to publish, create, and serve websites');
       expect(modifiedBlock.querySelector('img').src).to.equal(IMAGE);
     });

--- a/test/components/block-renderer/block-renderer.test.js
+++ b/test/components/block-renderer/block-renderer.test.js
@@ -372,7 +372,6 @@ describe('BlockRenderer', () => {
 
       const img = cardsBlock.querySelector('img');
       img.src = IMAGE;
-      await aTimeout(1000);
       const wrapper = blockRenderer.getBlockWrapper();
       const modifiedBlock = wrapper.querySelector('.cards');
 

--- a/test/components/block-renderer/block-renderer.test.js
+++ b/test/components/block-renderer/block-renderer.test.js
@@ -13,7 +13,7 @@
 /* eslint-disable no-unused-expressions */
 
 import {
-  html, fixture, expect, waitUntil,
+  html, fixture, expect, aTimeout, waitUntil,
 } from '@open-wc/testing';
 import '../../../src/components/block-renderer/block-renderer.js';
 import { stub } from 'sinon';
@@ -372,10 +372,9 @@ describe('BlockRenderer', () => {
 
       const img = cardsBlock.querySelector('img');
       img.src = IMAGE;
+      await aTimeout(1000);
       const wrapper = blockRenderer.getBlockWrapper();
-      await waitUntil(() => wrapper.querySelector('.cards strong').textContent === 'hello world 1', 'manually updated text did not update');
       const modifiedBlock = wrapper.querySelector('.cards');
-
       expect(modifiedBlock.querySelector('p:nth-of-type(2)').textContent).to.equal('hello world 2Helix is the fastest way to publish, create, and serve websites');
       expect(modifiedBlock.querySelector('img').src).to.equal(IMAGE);
     });

--- a/test/plugins/blocks/blocks.test.js
+++ b/test/plugins/blocks/blocks.test.js
@@ -532,9 +532,9 @@ describe('Blocks Plugin', () => {
 
       expect(copiedHTML.querySelectorAll(':scope > div').length).to.eq(1);
       expect(copiedHTML.querySelectorAll(':scope table').length).to.eq(3);
-      expect(copiedHTML.querySelector('table:nth-of-type(1) tr td').textContent).to.eq('z pattern');
-      expect(copiedHTML.querySelector('table:nth-of-type(2) tr td').textContent).to.eq('banner (small, left)');
-      expect(copiedHTML.querySelector('table:nth-of-type(3) tr td').textContent).to.eq('section metadata');
+      expect(copiedHTML.querySelector('table:nth-of-type(1) tr td').textContent).to.eq('Z Pattern');
+      expect(copiedHTML.querySelector('table:nth-of-type(2) tr td').textContent).to.eq('Banner (small, left)');
+      expect(copiedHTML.querySelector('table:nth-of-type(3) tr td').textContent).to.eq('Section Metadata');
 
       return copiedHTML;
     }
@@ -581,8 +581,8 @@ describe('Blocks Plugin', () => {
       const copiedHTML = createTag('div', undefined, clipboardHTML);
       expect(copiedHTML.querySelectorAll(':scope > div').length).to.eq(2);
       expect(copiedHTML.querySelectorAll(':scope table').length).to.eq(3);
-      expect(copiedHTML.querySelector('table:nth-of-type(1) tr td').textContent).to.eq('blockquote');
-      expect(copiedHTML.querySelector('table:nth-of-type(2) tr td').textContent).to.eq('section metadata');
+      expect(copiedHTML.querySelector('table:nth-of-type(1) tr td').textContent).to.eq('Blockquote');
+      expect(copiedHTML.querySelector('table:nth-of-type(2) tr td').textContent).to.eq('Section Metadata');
 
       // eslint-disable-next-line max-len
       // expect(copiedHTML.querySelector('table:nth-of-type(2) tr td').textContent).to.eq('Metadata');
@@ -591,7 +591,7 @@ describe('Blocks Plugin', () => {
       // There should be 3 tables as per assert above.
       copiedHTML.querySelectorAll(':scope table').forEach((table, index) => {
         if (index === 2) {
-          expect(table.querySelector('tr td').textContent).to.eq('metadata');
+          expect(table.querySelector('tr td').textContent).to.eq('Metadata');
         }
       });
 
@@ -634,7 +634,7 @@ describe('Blocks Plugin', () => {
 
       // Make sure section metadata was copied
       const tds = copiedHTML.querySelectorAll('td');
-      const targetTd = Array.from(tds).find(td => td.textContent.trim() === 'section metadata');
+      const targetTd = Array.from(tds).find(td => td.textContent.trim() === 'Section Metadata');
       expect(targetTd).to.exist;
 
       return copiedHTML;
@@ -685,7 +685,7 @@ describe('Blocks Plugin', () => {
 
       // Make sure section metadata was copied
       const tds = copiedHTML.querySelectorAll('td');
-      const targetTd = Array.from(tds).find(td => td.textContent.trim() === 'section metadata');
+      const targetTd = Array.from(tds).find(td => td.textContent.trim() === 'Section Metadata');
       expect(targetTd).to.exist;
 
       return copiedHTML;
@@ -770,9 +770,9 @@ describe('Blocks Plugin', () => {
       expect(copiedHTML.querySelectorAll(':scope > div').length).to.eq(1);
       expect(copiedHTML.querySelectorAll(':scope table').length).to.eq(3);
       expect(copiedHTML.querySelector(':scope h2').textContent).to.eq('Heading');
-      expect(copiedHTML.querySelector('table:nth-of-type(1) tr td').textContent).to.eq('z pattern');
-      expect(copiedHTML.querySelector('table:nth-of-type(2) tr td').textContent).to.eq('banner (small, left)');
-      expect(copiedHTML.querySelector('table:nth-of-type(3) tr td').textContent).to.eq('section metadata');
+      expect(copiedHTML.querySelector('table:nth-of-type(1) tr td').textContent).to.eq('Z Pattern');
+      expect(copiedHTML.querySelector('table:nth-of-type(2) tr td').textContent).to.eq('Banner (small, left)');
+      expect(copiedHTML.querySelector('table:nth-of-type(3) tr td').textContent).to.eq('Section Metadata');
 
       return copiedHTML;
     }
@@ -814,13 +814,13 @@ describe('Blocks Plugin', () => {
       expect(copiedHTML.querySelectorAll(':scope > div').length).to.eq(2);
       expect(copiedHTML.querySelectorAll(':scope table').length).to.eq(3);
       expect(copiedHTML.querySelector(':scope h1').textContent).to.eq('My blog post about a subject');
-      expect(copiedHTML.querySelector('table:nth-of-type(1) tr td').textContent).to.eq('blockquote');
-      expect(copiedHTML.querySelector('table:nth-of-type(2) tr td').textContent).to.eq('section metadata');
+      expect(copiedHTML.querySelector('table:nth-of-type(1) tr td').textContent).to.eq('Blockquote');
+      expect(copiedHTML.querySelector('table:nth-of-type(2) tr td').textContent).to.eq('Section Metadata');
 
       // See above for this sillyness
       copiedHTML.querySelectorAll(':scope table').forEach((table, index) => {
         if (index === 2) {
-          expect(table.querySelector('tr td').textContent).to.eq('metadata');
+          expect(table.querySelector('tr td').textContent).to.eq('Metadata');
         }
       });
 

--- a/test/plugins/blocks/utils.test.js
+++ b/test/plugins/blocks/utils.test.js
@@ -98,12 +98,12 @@ describe('Blocks Util', () => {
   describe('getBlockTableStyle', () => {
     it('prefers section library metadata over default library metadata', () => {
       const defaultMetadata = {
-        tableHeaderBackgroundColor: 'red',
-        tableHeaderForegroundColor: 'blue',
+        tableheaderbackgroundcolor: 'red',
+        tableheaderforegroundcolor: 'blue',
       };
       const sectionMetadata = {
-        tableHeaderBackgroundColor: 'green',
-        tableHeaderForegroundColor: 'yellow',
+        tableheaderbackgroundcolor: 'green',
+        tableheaderforegroundcolor: 'yellow',
       };
       const result = getBlockTableStyle(defaultMetadata, sectionMetadata);
       expect(result).to.deep.equal({
@@ -114,8 +114,8 @@ describe('Blocks Util', () => {
 
     it('falls back to default library metadata if section library metadata is missing', () => {
       const defaultMetadata = {
-        tableHeaderBackgroundColor: 'red',
-        tableHeaderForegroundColor: 'blue',
+        tableheaderbackgroundcolor: 'red',
+        tableheaderforegroundcolor: 'blue',
       };
       const sectionMetadata = {};
       const result = getBlockTableStyle(defaultMetadata, sectionMetadata);
@@ -136,48 +136,48 @@ describe('Blocks Util', () => {
   describe('getPreferedBackgroundColor', () => {
     it('returns the correct color for "section metadata" block', () => {
       document.documentElement.style.setProperty('--sk-section-metadata-table-background-color', '#123456');
-      expect(getPreferedBackgroundColor('section metadata')).to.equal('#123456');
+      expect(getPreferedBackgroundColor('Section Metadata')).to.equal('#123456');
     });
 
     it('returns the correct color for "metadata" block', () => {
       document.documentElement.style.setProperty('--sk-metadata-table-background-color', '#654321');
-      expect(getPreferedBackgroundColor('metadata')).to.equal('#654321');
+      expect(getPreferedBackgroundColor('Metadata')).to.equal('#654321');
     });
 
     it('returns the correct color for an unspecified block', () => {
       document.documentElement.style.setProperty('--sk-block-table-background-color', '#abcdef');
-      expect(getPreferedBackgroundColor('some other block')).to.equal('#abcdef');
+      expect(getPreferedBackgroundColor('Some Other Block')).to.equal('#abcdef');
     });
 
     it('falls back to default color if the CSS variable is not set', () => {
       document.documentElement.style.removeProperty('--sk-section-metadata-table-background-color');
       document.documentElement.style.removeProperty('--sk-metadata-table-background-color');
       document.documentElement.style.removeProperty('--sk-block-table-background-color');
-      expect(getPreferedBackgroundColor('section metadata')).to.equal('#ff8012');
+      expect(getPreferedBackgroundColor('Section Metadata')).to.equal('#ff8012');
     });
   });
 
   describe('getPreferedForegroundColor', () => {
     it('returns the correct color for "section metadata" block', () => {
       document.documentElement.style.setProperty('--sk-section-metadata-table-foreground-color', '#123456');
-      expect(getPreferedForegroundColor('section metadata')).to.equal('#123456');
+      expect(getPreferedForegroundColor('Section Metadata')).to.equal('#123456');
     });
 
     it('returns the correct color for "metadata" block', () => {
       document.documentElement.style.setProperty('--sk-metadata-table-foreground-color', '#654321');
-      expect(getPreferedForegroundColor('metadata')).to.equal('#654321');
+      expect(getPreferedForegroundColor('Metadata')).to.equal('#654321');
     });
 
     it('returns the correct color for an unspecified block', () => {
       document.documentElement.style.setProperty('--sk-block-table-foreground-color', '#abcdef');
-      expect(getPreferedForegroundColor('some other block')).to.equal('#abcdef');
+      expect(getPreferedForegroundColor('Some Other Block')).to.equal('#abcdef');
     });
 
     it('falls back to default color if the CSS variable is not set', () => {
       document.documentElement.style.removeProperty('--sk-section-metadata-table-foreground-color');
       document.documentElement.style.removeProperty('--sk-metadata-table-foreground-color');
       document.documentElement.style.removeProperty('--sk-block-table-foreground-color');
-      expect(getPreferedForegroundColor('section metadata')).to.equal('#ffffff');
+      expect(getPreferedForegroundColor('Section Metadata')).to.equal('#ffffff');
     });
   });
 });

--- a/test/plugins/blocks/utils.test.js
+++ b/test/plugins/blocks/utils.test.js
@@ -13,7 +13,14 @@
 /* eslint-disable no-unused-expressions */
 
 import { expect } from '@open-wc/testing';
-import { getBlockName, normalizeBlockName, convertBlockToTable } from '../../../src/plugins/blocks/utils.js';
+import {
+  getBlockName,
+  normalizeBlockName,
+  convertBlockToTable,
+  getBlockTableStyle,
+  getPreferedBackgroundColor,
+  getPreferedForegroundColor,
+} from '../../../src/plugins/blocks/utils.js';
 import { mockBlock } from '../../fixtures/blocks.js';
 import { CARDS_DEFAULT_STUB, CARDS_WITH_ALIGNMENT_STUB } from '../../fixtures/stubs/cards.js';
 
@@ -45,10 +52,10 @@ describe('Blocks Util', () => {
   });
   describe('normalizeBlockName()', () => {
     it('returns author friendly names', async () => {
-      expect(normalizeBlockName('hero-main')).to.equal('hero main');
-      expect(normalizeBlockName('hero-main (layer-1)')).to.equal('hero main (layer 1)');
-      expect(normalizeBlockName('hero-main (layer-1, bold-italic)')).to.equal('hero main (layer 1, bold italic)');
-      expect(normalizeBlockName('hero-main-foo-bar (layer-1, bold-italic, underline)')).to.equal('hero main foo bar (layer 1, bold italic, underline)');
+      expect(normalizeBlockName('hero-main')).to.equal('Hero Main');
+      expect(normalizeBlockName('hero-main (layer-1)')).to.equal('Hero Main (layer 1)');
+      expect(normalizeBlockName('hero-main (layer-1, bold-italic)')).to.equal('Hero Main (layer 1, bold italic)');
+      expect(normalizeBlockName('hero-main-foo-bar (layer-1, bold-italic, underline)')).to.equal('Hero Main Foo Bar (layer 1, bold italic, underline)');
     });
   });
 
@@ -67,6 +74,110 @@ describe('Blocks Util', () => {
       const thirdDataRow = table.querySelector('tr:nth-of-type(4)');
       expect(thirdDataRow.querySelector('td:first-of-type').getAttribute('data-valign')).to.equal('middle');
       expect(thirdDataRow.querySelector('td:nth-of-type(2)').getAttribute('data-valign')).to.equal('middle');
+    });
+  });
+
+  describe('convertBlockToTable()', () => {
+    it('should preserve data-align & data-valign', async () => {
+      const cardsBlock = mockBlock(CARDS_WITH_ALIGNMENT_STUB);
+      const table = await convertBlockToTable({}, cardsBlock, 'cards', 'https://localhost:3000');
+      const firstDataRow = table.querySelector('tr:nth-of-type(2)');
+      expect(firstDataRow.querySelector('td:first-of-type').getAttribute('data-align')).to.equal('center');
+      expect(firstDataRow.querySelector('td:first-of-type').getAttribute('data-valign')).to.equal('middle');
+
+      const secondDataRow = table.querySelector('tr:nth-of-type(3)');
+      expect(secondDataRow.querySelector('td:first-of-type').getAttribute('data-align')).to.equal('center');
+      expect(secondDataRow.querySelector('td:nth-of-type(2)').getAttribute('data-align')).to.equal('center');
+
+      const thirdDataRow = table.querySelector('tr:nth-of-type(4)');
+      expect(thirdDataRow.querySelector('td:first-of-type').getAttribute('data-valign')).to.equal('middle');
+      expect(thirdDataRow.querySelector('td:nth-of-type(2)').getAttribute('data-valign')).to.equal('middle');
+    });
+  });
+
+  describe('getBlockTableStyle', () => {
+    it('prefers section library metadata over default library metadata', () => {
+      const defaultMetadata = {
+        tableHeaderBackgroundColor: 'red',
+        tableHeaderForegroundColor: 'blue',
+      };
+      const sectionMetadata = {
+        tableHeaderBackgroundColor: 'green',
+        tableHeaderForegroundColor: 'yellow',
+      };
+      const result = getBlockTableStyle(defaultMetadata, sectionMetadata);
+      expect(result).to.deep.equal({
+        tableHeaderBackgroundColor: 'green',
+        tableHeaderForegroundColor: 'yellow',
+      });
+    });
+
+    it('falls back to default library metadata if section library metadata is missing', () => {
+      const defaultMetadata = {
+        tableHeaderBackgroundColor: 'red',
+        tableHeaderForegroundColor: 'blue',
+      };
+      const sectionMetadata = {};
+      const result = getBlockTableStyle(defaultMetadata, sectionMetadata);
+      expect(result).to.deep.equal({
+        tableHeaderBackgroundColor: 'red',
+        tableHeaderForegroundColor: 'blue',
+      });
+    });
+
+    it('returns an empty object if both metadata objects are missing the properties', () => {
+      const defaultMetadata = {};
+      const sectionMetadata = {};
+      const result = getBlockTableStyle(defaultMetadata, sectionMetadata);
+      expect(result).to.be.empty;
+    });
+  });
+
+  describe('getPreferedBackgroundColor', () => {
+    it('returns the correct color for "section metadata" block', () => {
+      document.documentElement.style.setProperty('--sk-section-metadata-table-background-color', '#123456');
+      expect(getPreferedBackgroundColor('section metadata')).to.equal('#123456');
+    });
+
+    it('returns the correct color for "metadata" block', () => {
+      document.documentElement.style.setProperty('--sk-metadata-table-background-color', '#654321');
+      expect(getPreferedBackgroundColor('metadata')).to.equal('#654321');
+    });
+
+    it('returns the correct color for an unspecified block', () => {
+      document.documentElement.style.setProperty('--sk-block-table-background-color', '#abcdef');
+      expect(getPreferedBackgroundColor('some other block')).to.equal('#abcdef');
+    });
+
+    it('falls back to default color if the CSS variable is not set', () => {
+      document.documentElement.style.removeProperty('--sk-section-metadata-table-background-color');
+      document.documentElement.style.removeProperty('--sk-metadata-table-background-color');
+      document.documentElement.style.removeProperty('--sk-block-table-background-color');
+      expect(getPreferedBackgroundColor('section metadata')).to.equal('#ff8012');
+    });
+  });
+
+  describe('getPreferedForegroundColor', () => {
+    it('returns the correct color for "section metadata" block', () => {
+      document.documentElement.style.setProperty('--sk-section-metadata-table-foreground-color', '#123456');
+      expect(getPreferedForegroundColor('section metadata')).to.equal('#123456');
+    });
+
+    it('returns the correct color for "metadata" block', () => {
+      document.documentElement.style.setProperty('--sk-metadata-table-foreground-color', '#654321');
+      expect(getPreferedForegroundColor('metadata')).to.equal('#654321');
+    });
+
+    it('returns the correct color for an unspecified block', () => {
+      document.documentElement.style.setProperty('--sk-block-table-foreground-color', '#abcdef');
+      expect(getPreferedForegroundColor('some other block')).to.equal('#abcdef');
+    });
+
+    it('falls back to default color if the CSS variable is not set', () => {
+      document.documentElement.style.removeProperty('--sk-section-metadata-table-foreground-color');
+      document.documentElement.style.removeProperty('--sk-metadata-table-foreground-color');
+      document.documentElement.style.removeProperty('--sk-block-table-foreground-color');
+      expect(getPreferedForegroundColor('section metadata')).to.equal('#ffffff');
     });
   });
 });


### PR DESCRIPTION
Adds support for custom table header background and foreground colors (blocks, section metadata & metadata) via css variables and library metadata.
Fixes normalized block names..  the first letter in every word of block names will be uppercased, variations will not be uppercased).

Fix #80