### PR TITLE
fix: all content editable to be disabled

### DIFF
--- a/src/components/block-renderer/block-renderer.js
+++ b/src/components/block-renderer/block-renderer.js
@@ -254,7 +254,14 @@ export class BlockRenderer extends LitElement {
    * @param {HTMLElement} hostContainer The host container to render the iframe into
    */
   // eslint-disable-next-line no-unused-vars
-  async loadBlock(blockName, blockData, blockWrapper, defaultLibraryMetadata, hostContainer) {
+  async loadBlock(
+    blockName,
+    blockData,
+    blockWrapper,
+    defaultLibraryMetadata,
+    sectionLibraryMetadata,
+    hostContainer,
+  ) {
     const { context } = AppModel.appStore;
     const { url: blockURL } = blockData;
     const origin = blockData.extended
@@ -291,8 +298,16 @@ export class BlockRenderer extends LitElement {
     const sidekickLibraryClass = 'sidekick-library';
     content?.classList.add(sidekickLibraryClass);
 
-    // Decorate the block with ids
-    this.decorateEditableElements(content);
+    // Should the content be editable?
+    const editable = sectionLibraryMetadata.contenteditable
+      ?? defaultLibraryMetadata.contenteditable
+      ?? context.contentEditable
+      ?? true;
+
+    // Editable can be a boolean or a string
+    if (editable.toString() === 'true') {
+      this.decorateEditableElements(content);
+    }
 
     // Clone the block and decorate it
     const blockClone = blockWrapper.cloneNode(true);

--- a/src/plugins/blocks/blocks.js
+++ b/src/plugins/blocks/blocks.js
@@ -295,6 +295,7 @@ function loadBlock(context, event, container) {
     blockData,
     blockWrapper,
     defaultLibraryMetadata,
+    sectionLibraryMetadata,
     container,
   );
 
@@ -346,6 +347,7 @@ function loadTemplate(context, event, container) {
     blockData,
     blockWrapper,
     defaultLibraryMetadata,
+    sectionLibraryMetadata,
     container,
   );
 


### PR DESCRIPTION
Allow contentEditable to be disable globally via config, in section library metadata or in default library metadata.

Fixes #102 